### PR TITLE
Add in missing methods that loctool plugins require

### DIFF
--- a/IosStringsFile.js
+++ b/IosStringsFile.js
@@ -137,7 +137,7 @@ IosStringsFile.prototype.extract = function() {
 
             logger.trace("origin is " + this.origin + " and sourcePath is " + this.sourcePath);
 
-            var buffer = new Buffer(2);
+            var buffer = Buffer.alloc(2);
             buffer.fill(0);
 
             var fd = fs.openSync(p, 'r');

--- a/IosStringsFileType.js
+++ b/IosStringsFileType.js
@@ -303,4 +303,59 @@ IosStringsFileType.prototype.getExtensions = function() {
     return this.extensions;
 };
 
+/**
+ * Return the translation set containing all of the extracted
+ * resources for all instances of this type of file. This includes
+ * all new strings and all existing strings. If it was extracted
+ * from a source file, it should be returned here.
+ *
+ * @returns {TranslationSet} the set containing all of the
+ * extracted resources
+ */
+IosStringsFileType.prototype.getExtracted = function() {
+    return this.extracted;
+};
+
+/**
+ * Add the contents of the given translation set to the extracted resources
+ * for this file type.
+ *
+ * @param {TranslationSet} set set of resources to add to the current set
+ */
+IosStringsFileType.prototype.addSet = function(set) {
+    this.extracted.addSet(set);
+};
+
+/**
+ * Return the translation set containing all of the new
+ * resources for all instances of this type of file.
+ *
+ * @returns {TranslationSet} the set containing all of the
+ * new resources
+ */
+IosStringsFileType.prototype.getNew = function() {
+    return this.newres;
+};
+
+/**
+ * Return the translation set containing all of the pseudo
+ * localized resources for all instances of this type of file.
+ *
+ * @returns {TranslationSet} the set containing all of the
+ * pseudo localized resources
+ */
+IosStringsFileType.prototype.getPseudo = function() {
+    return this.pseudo;
+};
+
+/**
+ * Return the list of file name extensions that this plugin can
+ * process.
+ *
+ * @returns {Array.<string>} the list of file name extensions
+ */
+IosStringsFileType.prototype.getExtensions = function() {
+    return this.extensions;
+};
+
 module.exports = IosStringsFileType;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-strings",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "main": "./IosStringsFileType.js",
     "description": "A loctool plugin that knows how to process iOS .strings files",
     "license": "Apache-2.0",


### PR DESCRIPTION
Also, fixed deprected new Buffer to Buffer.alloc()
Also, v1.0.0 -> v1.1.0