### PR TITLE
Allow better behaviour as a resource file type

### DIFF
--- a/IosStringsFile.js
+++ b/IosStringsFile.js
@@ -42,12 +42,12 @@ var IosStringsFile = function(props) {
         this.project = props.project;
         this.pathName = props.pathName;
         this.type = props.type;
-        this.locale = this.iosLocale = props.locale;
+        this.locale = this.iosLocale = props.locale || this.project.settings.targetLocale;
         this.context = props.context || undefined;
         this.flavor = props.flavor;
     }
 
-    if (this.pathName) {
+    if (this.pathName && !this.locale) {
         this._parsePath();
     }
 
@@ -290,11 +290,28 @@ function localeContains(parent, child) {
  */
 IosStringsFile.prototype.addResource = function(res) {
     logger.trace("IosStringsFile.addResource: " + JSON.stringify(res) + " to " + this.project.getProjectId() + ", " + res.getTargetLocale());
-    if (res &&
-            res.getProject() === this.project.getProjectId() &&
-            localeContains(this.locale, res.getTargetLocale())) {
-        logger.trace("correct project and locale. Adding.");
-        this.set.add(res);
+    if (res && res.getProject() === this.project.getProjectId()) {
+        if (localeContains(this.locale, res.getTargetLocale())) {
+            logger.trace("correct project and locale. Adding.");
+            this.set.add(res);
+        } else {
+            logger.trace("correct project, wrong locale. Adding as a source-only resource.");
+            // This one is not the right locale, so add it as a source-only resource
+            // so that it can be a placeholder for the real translation later on
+            this.set.add(this.API.newResource({
+                resType: res.getType(),
+                source: res.getSource(),
+                sourceLocale: res.getSourceLocale(),
+                project: res.getProject(),
+                key: res.getKey(),
+                pathName: res.getPath(),
+                state: "new",
+                comment: res.getComment(),
+                datatype: this.type.datatype,
+                context: res.getContext(),
+                index: this.resourceIndex++
+            }));
+        }
     } else {
         if (res) {
             if (res.getProject() !== this.project.getProjectId()) {

--- a/IosStringsFile.js
+++ b/IosStringsFile.js
@@ -220,11 +220,11 @@ IosStringsFile.prototype._parsePath = function() {
         }
         logger.trace("_parsePath: locale is " + this.locale);
 
-        if (this.project.flavors) {
+        if (this.project.settings.flavors) {
             var filename = path.basename(this.pathName, ".strings");
-            var i = this.project.flavors.indexOf(filename);
+            var i = this.project.settings.flavors.indexOf(filename);
             if (i > -1) {
-                this.flavor = this.project.flavors[i];
+                this.flavor = this.project.settings.flavors[i];
             }
         }
     }

--- a/IosStringsFile.js
+++ b/IosStringsFile.js
@@ -47,7 +47,7 @@ var IosStringsFile = function(props) {
         this.flavor = props.flavor;
     }
 
-    if (this.pathName && !this.locale) {
+    if (this.pathName) {
         this._parsePath();
     }
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # ilib-loctool-strings
+
 Ilib loctool plugin to parse and localize iOS .strings files
+
+## Release Notes
+
+### v1.2.0
+
+- Added the ability to set the target locale for the file from the
+  project settings if it is there. Otherwise, fall back to parsing
+  the path name to find the locale.

--- a/README.md
+++ b/README.md
@@ -9,3 +9,4 @@ Ilib loctool plugin to parse and localize iOS .strings files
 - Added the ability to set the target locale for the file from the
   project settings if it is there. Otherwise, fall back to parsing
   the path name to find the locale.
+- Fixed the way that flavors are detected in the path name

--- a/package.json
+++ b/package.json
@@ -50,11 +50,11 @@
         "node": ">=6.0"
     },
     "dependencies": {
-        "ilib": "^14.1.0",
+        "ilib": "^14.7.0",
         "log4js": "^2.11.0"
     },
     "devDependencies": {
-        "loctool": "^2.10.1",
+        "loctool": "^2.11.0",
         "nodeunit": "^0.11.3"
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-strings",
-    "version": "1.1.1",
+    "version": "1.2.0",
     "main": "./IosStringsFileType.js",
     "description": "A loctool plugin that knows how to process iOS .strings files",
     "license": "Apache-2.0",


### PR DESCRIPTION
- you can now add resources with a different target locale than the file. These will become source-only resources for this file.
- the plugin now looks at project.settings to find the target locale if the user has set one explicitly on the command-line