### PR TITLE
Fix initialization of pseudo locales

### DIFF
--- a/IosStringsFileType.js
+++ b/IosStringsFileType.js
@@ -50,7 +50,7 @@ var IosStringsFileType = function(project) {
     this.pseudos = {};
 
     // generate all the pseudo bundles we'll need
-    project.locales && project.locales.forEach(function(locale) {
+    project.settings && project.settings.locales && project.settings.locales.forEach(function(locale) {
         var pseudo = this.API.getPseudoBundle(locale, this, project);
         if (pseudo) {
             this.pseudos[locale] = pseudo;

--- a/README.md
+++ b/README.md
@@ -2,7 +2,18 @@
 
 Ilib loctool plugin to parse and localize iOS .strings files
 
+## License
+
+This plugin is license under Apache2. See the [LICENSE](./LICENSE)
+file for more details.
+
 ## Release Notes
+
+### v1.2.1
+
+- Fix a bug where the pseudo locales were not initialized properly.
+  This fix gets the right set of locales from the project settings to
+  see if any of them are pseudo locales.
 
 ### v1.2.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-strings",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "main": "./IosStringsFileType.js",
     "description": "A loctool plugin that knows how to process iOS .strings files",
     "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -50,12 +50,12 @@
         "node": ">=6.0"
     },
     "dependencies": {
-        "ilib": "^14.7.0",
+        "ilib": "^14.9.0",
         "log4js": "^2.11.0"
     },
     "devDependencies": {
         "assertextras": "^1.1.0",
-        "loctool": "^2.11.0",
+        "loctool": "^2.13.0",
         "nodeunit": "^0.11.3"
     }
 }


### PR DESCRIPTION
- Fix a bug where the pseudo locales were not initialized properly. This fix gets the right set of locales from the project settings to see if any of them are pseudo locales.